### PR TITLE
Added Max Payne 3 Arcade Mode

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -3344,7 +3344,8 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
-            <Game>Max Payne 3</Game>
+	    <Game>Max Payne 3</Game>
+	    <Game>Max Payne 3 Arcade Mode</Game>
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/gunlinux/LiveSplit.MaxPayne3/main/LiveSplit.MaxPayne3.asl</URL>


### PR DESCRIPTION
Added autosplitter support for Max Payne 3 Arcade Mode

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [ ] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [ ] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [ ] The Auto Splitter has an open source license that allows anyone to fork and host it.
